### PR TITLE
Changes to Player Deaths

### DIFF
--- a/src/com/palmergames/bukkit/towny/war/eventwar/War.java
+++ b/src/com/palmergames/bukkit/towny/war/eventwar/War.java
@@ -268,8 +268,11 @@ public class War {
 		if (hp > 0) {
 			warZone.put(worldCoord, hp);
 			//TownyMessaging.sendMessageToMode(townBlock.getTown(), Colors.Gray + "[" + townBlock.getTown().getName() + "](" + townBlock.getCoord().toString() + ") HP: " + hp, "");
+			TownyMessaging.sendMessageToMode(townBlock.getTown(), Colors.Red + "Your town is under attack! (" + townBlock.getCoord().toString() + ") HP: " + hp, "");
 			if ((hp >= 10 && hp % 10 == 0) || hp <= 5){
-				TownyMessaging.sendMessageToMode(townBlock.getTown().getNation(), Colors.Red + "Your nation is under attack! [" + townBlock.getTown().getName() + "](" + townBlock.getCoord().toString() + ") HP: " + hp, "");
+				for (Town town: townBlock.getTown().getNation().getTowns())
+					if (town != townBlock.getTown())
+						TownyMessaging.sendMessageToMode(town, Colors.Red + "Your nation is under attack! [" + townBlock.getTown().getName() + "](" + townBlock.getCoord().toString() + ") HP: " + hp, "");
 			}
 			TownyMessaging.sendMessageToMode(attacker, Colors.Gray + "[" + townBlock.getTown().getName() + "](" + townBlock.getCoord().toString() + ") HP: " + hp, "");
 		} else


### PR DESCRIPTION
-The only time a king/mayor death cause the nation/town to fall and the
only time points are awarded for kills is when both the attacker and
defender are players and both are in warring towns.
-Members of the defending town get a notification for each call to
damage while members of that nation not in the town get notifications
every 10 hp.