### PR TITLE
HUD Fixes + War HP Regen

### DIFF
--- a/src/com/palmergames/bukkit/towny/huds/HUDManager.java
+++ b/src/com/palmergames/bukkit/towny/huds/HUDManager.java
@@ -15,7 +15,6 @@ import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
 import com.palmergames.bukkit.towny.object.Coord;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.TownBlock;
-import com.palmergames.bukkit.towny.object.TownyUniverse;
 import com.palmergames.bukkit.towny.object.WorldCoord;
 import com.palmergames.bukkit.towny.war.eventwar.PlotAttackedEvent;
 import com.palmergames.bukkit.towny.war.eventwar.TownScoredEvent;
@@ -27,7 +26,8 @@ public class HUDManager implements Listener{
 	ArrayList<Player> warUsers;
 	ArrayList<Player> permUsers;
 
-	Towny plugin;
+	private final Towny plugin;
+	
 	public HUDManager (Towny plugin) {
 		this.plugin = plugin;
 		warUsers = new ArrayList<Player>();
@@ -38,6 +38,7 @@ public class HUDManager implements Listener{
 	public void toggleWarHUD (Player p) {
 		if (!warUsers.contains(p)){
 			toggleAllOff(p);
+			warUsers.add(p);
 			WarHUD.toggleOn(p, plugin.getTownyUniverse().getWarEvent());
 		} else 
 			toggleAllOff(p);
@@ -46,6 +47,7 @@ public class HUDManager implements Listener{
 	public void togglePermHuD (Player p) {
 		if (!permUsers.contains(p)) {
 			toggleAllOff(p);
+			permUsers.add(p);
 			PermHUD.toggleOn(p);
 		} else 
 			toggleAllOff(p);

--- a/src/com/palmergames/bukkit/towny/huds/PermHUD.java
+++ b/src/com/palmergames/bukkit/towny/huds/PermHUD.java
@@ -85,8 +85,8 @@ public class PermHUD {
 		String permsTitle_player = ChatColor.YELLOW + "" + ChatColor.UNDERLINE + "Plot Perms";
 		String build_player = ChatColor.DARK_GREEN + "Build: " + ChatColor.GRAY;
 		String destroy_player = ChatColor.DARK_GREEN + "Destroy: " + ChatColor.GRAY;
-		String switching_player = ChatColor.DARK_GREEN + "Switching: " + ChatColor.GRAY;
-		String item_player = ChatColor.DARK_GREEN + "item: " + ChatColor.GRAY;
+		String switching_player = ChatColor.DARK_GREEN + "Switch: " + ChatColor.GRAY;
+		String item_player = ChatColor.DARK_GREEN + "Item: " + ChatColor.GRAY;
 		String pvp_player = ChatColor.DARK_GREEN + "PvP: ";
 		String explosions_player = ChatColor.DARK_GREEN + "Explosions: ";
 		String firespread_player = ChatColor.DARK_GREEN + "Firespread: ";
@@ -95,8 +95,8 @@ public class PermHUD {
 		String keyTitle_player = ChatColor.YELLOW + "" + ChatColor.UNDERLINE + "Key";
 		String keyResident_player = ChatColor.DARK_GREEN + "" + ChatColor.BOLD + "r" + ChatColor.WHITE + " - " + ChatColor.GRAY + "residents";
 		String keyFriend_player = ChatColor.DARK_GREEN + "" + ChatColor.BOLD + "f" + ChatColor.WHITE + " - " + ChatColor.GRAY + "friends";
-		String keyAlly_player = ChatColor.DARK_GREEN + "" + ChatColor.BOLD + "r" + ChatColor.WHITE + " - " + ChatColor.GRAY + "allies";
-		String keyOutsider_player = ChatColor.DARK_GREEN + "" + ChatColor.BOLD + "r" + ChatColor.WHITE + " - " + ChatColor.GRAY + "outsiders";
+		String keyAlly_player = ChatColor.DARK_GREEN + "" + ChatColor.BOLD + "a" + ChatColor.WHITE + " - " + ChatColor.GRAY + "allies";
+		String keyOutsider_player = ChatColor.DARK_GREEN + "" + ChatColor.BOLD + "o" + ChatColor.WHITE + " - " + ChatColor.GRAY + "outsiders";
 		//init objective
 		Scoreboard board = Bukkit.getScoreboardManager().getNewScoreboard();
 		Objective obj = board.registerNewObjective("PERM_HUD_OBJ", "dummy");

--- a/src/com/palmergames/bukkit/towny/huds/WarHUD.java
+++ b/src/com/palmergames/bukkit/towny/huds/WarHUD.java
@@ -24,7 +24,7 @@ public class WarHUD {
 
 	final static int home_health = TownySettings.getWarzoneHomeBlockHealth();
 	final static int town_health = TownySettings.getWarzoneTownBlockHealth();
-	
+
 	public static void updateLocation(Player p, WorldCoord at) {
 		String nation_loc, town_loc, homeblock;
 		try {
@@ -57,13 +57,15 @@ public class WarHUD {
 		String health;
 		boolean isTown = false;
 		try { 
-			if (at.getTownBlock().isWarZone()) 
+			if (at.getTownBlock().isWarZone()) {
 				health = war.getWarZone().get(at) + "" + ChatColor.AQUA + "/" + (at.getTownBlock().isHomeBlock() ? home_health : town_health);
-			isTown = true;
-			if (at.getTownBlock().getTown().getNation().isNeutral())
-				health = "Neutral";
-			else
-				health = "Fallen";
+			} else {
+				isTown = true;
+				if (at.getTownBlock().getTown().getNation().isNeutral())
+					health = "Neutral";
+				else
+					health = "Fallen";
+			}
 		} catch (NotRegisteredException e) {
 			if (isTown)
 				health = "Neutral";
@@ -72,7 +74,7 @@ public class WarHUD {
 		}
 		p.getScoreboard().getTeam("health").setSuffix(health);
 	}
-	
+
 	public static void updateHealth (Player p, int health, boolean home) {
 		if (health > 0) 
 			p.getScoreboard().getTeam("health").setSuffix(health + "" + ChatColor.AQUA + "/" + (home ? home_health : town_health));
@@ -82,7 +84,7 @@ public class WarHUD {
 				p.getScoreboard().getTeam("edge").setSuffix("False");
 		}
 	}
-	
+
 	public static void updateHomeTown(Player p) {
 		String homeTown;
 		try {
@@ -92,7 +94,7 @@ public class WarHUD {
 		}
 		p.getScoreboard().getTeam("town_title").setSuffix(HUDManager.check(homeTown));
 	}
-	
+
 	public static void updateScore(Player p, War war) {
 		String score;
 		try {
@@ -105,7 +107,7 @@ public class WarHUD {
 		} catch (NotRegisteredException e) {score = "";}
 		p.getScoreboard().getTeam("town_score").setSuffix(HUDManager.check(score));
 	}
-	
+
 	public static void updateTopScores(Player p, String[] top) {
 		String fprefix = top[0].contains("-") ? ChatColor.GOLD + top[0].split("-")[0] + ChatColor.WHITE + "-": "";
 		String sprefix = top[1].contains("-") ? ChatColor.GRAY + top[1].split("-")[0] + ChatColor.WHITE + "-": "";
@@ -120,7 +122,7 @@ public class WarHUD {
 		p.getScoreboard().getTeam("third").setPrefix(HUDManager.check(tprefix));
 		p.getScoreboard().getTeam("third").setSuffix(HUDManager.check(tsuffix));
 	}
-	
+
 	public static void updateScore(Player p, int score) {
 		p.getScoreboard().getTeam("town_score").setSuffix(HUDManager.check(score + ""));
 	}

--- a/src/com/palmergames/bukkit/towny/war/eventwar/War.java
+++ b/src/com/palmergames/bukkit/towny/war/eventwar/War.java
@@ -275,6 +275,18 @@ public class War {
 		TownScoredEvent event = new TownScoredEvent(attackerTown, townScores.get(attackerTown));
 		Bukkit.getServer().getPluginManager().callEvent(event);
 	}
+	
+	public void heal(Player healPlayer, TownBlock townBlock) throws NotRegisteredException {
+		WorldCoord worldCoord = townBlock.getWorldCoord();
+		if (townBlock.isHomeBlock() && warZone.get(worldCoord) == TownySettings.getWarzoneHomeBlockHealth())
+			return;
+		if (!townBlock.isHomeBlock() && warZone.get(worldCoord) == TownySettings.getWarzoneTownBlockHealth())
+			return;
+		int hp = warZone.get(worldCoord) + 1;
+		warZone.put(worldCoord, hp);
+		Resident healResident = TownyUniverse.getDataSource().getResident(healPlayer.getName());
+		TownyMessaging.sendMessageToMode(healResident.getTown(), Colors.Gray + "[Heal](" + townBlock.getCoord().toString() + ") HP: " + hp, "");
+	}
 
 	public void damage(Player attackerPlayer, TownBlock townBlock) throws NotRegisteredException {
 

--- a/src/com/palmergames/bukkit/towny/war/eventwar/WarTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/war/eventwar/WarTimerTask.java
@@ -66,8 +66,10 @@ public class WarTimerTask extends TownyTimerTask {
 							continue;
 						TownyMessaging.sendDebugMsg("[War]   aboveMinHeight");
 						TownBlock townBlock = worldCoord.getTownBlock(); //universe.getWorld(player.getWorld().getName()).getTownBlock(worldCoord);
-						if (nation == townBlock.getTown().getNation() || townBlock.getTown().getNation().hasAlly(nation))
+						if (nation == townBlock.getTown().getNation() || townBlock.getTown().getNation().hasAlly(nation)) {
+							warEvent.heal(player, townBlock);
 							continue;
+						}
 						TownyMessaging.sendDebugMsg("[War]   notAlly");
 						//Enemy nation
 						


### PR DESCRIPTION
Fixed some bug with HUDs. Players can regen townblock HP in war if they
are an ally or part of the nation.