### PR TITLE
Update Towny to 1.9

### DIFF
--- a/src/com/palmergames/bukkit/towny/Towny.java
+++ b/src/com/palmergames/bukkit/towny/Towny.java
@@ -26,6 +26,7 @@ import com.palmergames.util.JavaUtil;
 import com.palmergames.util.StringMgmt;
 import com.palmergames.bukkit.towny.huds.*;
 
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
@@ -139,7 +140,7 @@ public class Towny extends JavaPlugin {
 
 		if (!isError()) {
 			// Re login anyone online. (In case of plugin reloading)
-			for (Player player : BukkitTools.getOnlinePlayers())
+			for (Player player : Bukkit.getServer().getOnlinePlayers())
 				if (player != null)
 					try {
 						getTownyUniverse().onLogin(player);
@@ -511,7 +512,7 @@ public class Towny extends JavaPlugin {
 	 */
 	public void resetCache() {
 
-		for (Player player : BukkitTools.getOnlinePlayers())
+		for (Player player : Bukkit.getServer().getOnlinePlayers())
 			if (player != null)
 				getCache(player).resetAndUpdate(new WorldCoord(player.getWorld().getName(), Coord.parseCoord(player))); // Automatically
 																														// resets
@@ -523,7 +524,7 @@ public class Towny extends JavaPlugin {
 	 */
 	public void updateCache(WorldCoord worldCoord) {
 
-		for (Player player : BukkitTools.getOnlinePlayers())
+		for (Player player : Bukkit.getServer().getOnlinePlayers())
 			if (player != null)
 				if (Coord.parseCoord(player).equals(worldCoord))
 					getCache(player).resetAndUpdate(worldCoord); // Automatically
@@ -538,7 +539,7 @@ public class Towny extends JavaPlugin {
 
 		WorldCoord worldCoord = null;
 
-		for (Player player : BukkitTools.getOnlinePlayers()) {
+		for (Player player : Bukkit.getServer().getOnlinePlayers()) {
 			if (player != null) {
 				worldCoord = new WorldCoord(player.getWorld().getName(), Coord.parseCoord(player));
 				PlayerCache cache = getCache(player);

--- a/src/com/palmergames/bukkit/towny/TownyMessaging.java
+++ b/src/com/palmergames/bukkit/towny/TownyMessaging.java
@@ -2,6 +2,7 @@ package com.palmergames.bukkit.towny;
 
 import java.util.List;
 
+import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
@@ -274,7 +275,7 @@ public class TownyMessaging {
 		for (String line : lines) {
 			TownyLogger.log.info(ChatTools.stripColour("[Global Msg] " + line));
 		}
-		for (Player player : BukkitTools.getOnlinePlayers())
+		for (Player player : Bukkit.getServer().getOnlinePlayers())
 			if (player != null)
 				for (String line : lines)
 					player.sendMessage(line);
@@ -288,7 +289,7 @@ public class TownyMessaging {
 	public static void sendGlobalMessage(String line) {
 
 		TownyLogger.log.info(ChatTools.stripColour("[Global Message] " + line));
-		for (Player player : BukkitTools.getOnlinePlayers()) {
+		for (Player player : Bukkit.getServer().getOnlinePlayers()) {
 			if (player != null)
 				try {
 					if (TownyUniverse.getDataSource().getWorld(player.getLocation().getWorld().getName()).isUsingTowny())

--- a/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -169,7 +169,7 @@ public class TownyPlayerListener implements Listener {
 
 		// Test against the item in hand as we need to test the bucket contents
 		// we are trying to empty.
-		event.setCancelled(onPlayerInteract(event.getPlayer(), event.getBlockClicked(), event.getPlayer().getItemInHand()));
+		event.setCancelled(onPlayerInteract(event.getPlayer(), event.getBlockClicked(), event.getPlayer().getInventory().getItemInMainHand()));
 
 		// Test on the resulting empty bucket to see if we have permission to
 		// empty a bucket.
@@ -230,7 +230,7 @@ public class TownyPlayerListener implements Listener {
 			/*
 			 * Info Tool
 			 */
-			if (event.getPlayer().getItemInHand().getType() == Material.getMaterial(TownySettings.getTool())) {
+			if (event.getPlayer().getInventory().getItemInMainHand().getType() == Material.getMaterial(TownySettings.getTool())) {
 
 				if (TownyUniverse.getPermissionSource().isTownyAdmin(player)) {
 					if (event.getClickedBlock() instanceof Block) {
@@ -344,12 +344,12 @@ public class TownyPlayerListener implements Listener {
 			/*
 			 * Item_use protection.
 			 */
-			if (event.getPlayer().getItemInHand() != null) {
+			if (event.getPlayer().getInventory().getItemInMainHand() != null) {
 
 				/*
 				 * Info Tool
 				 */
-				if (event.getPlayer().getItemInHand().getType() == Material.getMaterial(TownySettings.getTool())) {
+				if (event.getPlayer().getInventory().getItemInMainHand().getType() == Material.getMaterial(TownySettings.getTool())) {
 
 					Entity entity = event.getRightClicked();
 
@@ -362,8 +362,8 @@ public class TownyPlayerListener implements Listener {
 
 				}
 
-				if (TownySettings.isItemUseMaterial(event.getPlayer().getItemInHand().getType().name())) {
-					event.setCancelled(onPlayerInteract(event.getPlayer(), null, event.getPlayer().getItemInHand()));
+				if (TownySettings.isItemUseMaterial(event.getPlayer().getInventory().getItemInMainHand().getType().name())) {
+					event.setCancelled(onPlayerInteract(event.getPlayer(), null, event.getPlayer().getInventory().getItemInMainHand()));
 					return;
 				}
 			}
@@ -473,12 +473,12 @@ public class TownyPlayerListener implements Listener {
 			/*
 			 * Item_use protection.
 			 */
-			if (event.getPlayer().getItemInHand() != null) {
+			if (event.getPlayer().getInventory().getItemInMainHand() != null) {
 
 				/*
 				 * Info Tool
 				 */
-				if (event.getPlayer().getItemInHand().getType() == Material.getMaterial(TownySettings.getTool())) {
+				if (event.getPlayer().getInventory().getItemInMainHand().getType() == Material.getMaterial(TownySettings.getTool())) {
 
 					Entity entity = event.getRightClicked();
 
@@ -491,8 +491,8 @@ public class TownyPlayerListener implements Listener {
 
 				}
 
-				if (TownySettings.isItemUseMaterial(event.getPlayer().getItemInHand().getType().name())) {
-					event.setCancelled(onPlayerInteract(event.getPlayer(), null, event.getPlayer().getItemInHand()));
+				if (TownySettings.isItemUseMaterial(event.getPlayer().getInventory().getItemInMainHand().getType().name())) {
+					event.setCancelled(onPlayerInteract(event.getPlayer(), null, event.getPlayer().getInventory().getItemInMainHand()));
 					return;
 				}
 			}

--- a/src/com/palmergames/bukkit/towny/object/TownyUniverse.java
+++ b/src/com/palmergames/bukkit/towny/object/TownyUniverse.java
@@ -20,6 +20,8 @@ import com.palmergames.bukkit.towny.war.eventwar.War;
 import com.palmergames.bukkit.util.BukkitTools;
 import com.palmergames.bukkit.util.NameValidation;
 import com.palmergames.util.FileMgmt;
+
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.Block;
@@ -105,7 +107,7 @@ public class TownyUniverse extends TownyObject {
 	 */
 	public static Player getPlayer(Resident resident) throws TownyException {
 
-		for (Player player : BukkitTools.getOnlinePlayers())
+		for (Player player : Bukkit.getServer().getOnlinePlayers())
 			if (player != null)
 				if (player.getName().equals(resident.getName()))
 					return player;
@@ -121,7 +123,7 @@ public class TownyUniverse extends TownyObject {
 	public static List<Player> getOnlinePlayers(ResidentList residents) {
 
 		ArrayList<Player> players = new ArrayList<Player>();
-		for (Player player : BukkitTools.getOnlinePlayers())
+		for (Player player : Bukkit.getServer().getOnlinePlayers())
 			if (player != null)
 				if (residents.hasResident(player.getName()))
 					players.add(player);
@@ -137,7 +139,7 @@ public class TownyUniverse extends TownyObject {
 	public static List<Player> getOnlinePlayers(Town town) {
 
 		ArrayList<Player> players = new ArrayList<Player>();
-		for (Player player : BukkitTools.getOnlinePlayers())
+		for (Player player : Bukkit.getServer().getOnlinePlayers())
 			if (player != null)
 				if (town.hasResident(player.getName()))
 					players.add(player);
@@ -529,7 +531,7 @@ public class TownyUniverse extends TownyObject {
 	public static List<Resident> getOnlineResidents(ResidentList residentList) {
 
 		List<Resident> onlineResidents = new ArrayList<Resident>();
-		for (Player player : BukkitTools.getOnlinePlayers()) {
+		for (Player player : Bukkit.getServer().getOnlinePlayers()) {
 			if (player != null)
 				for (Resident resident : residentList.getResidents()) {
 					if (resident.getName().equalsIgnoreCase(player.getName()))
@@ -543,7 +545,7 @@ public class TownyUniverse extends TownyObject {
 	public static List<Resident> getOnlineResidentsViewable(Player viewer, ResidentList residentList) {
 
 		List<Resident> onlineResidents = new ArrayList<Resident>();
-		for (Player player : BukkitTools.getOnlinePlayers()) {
+		for (Player player : Bukkit.getServer().getOnlinePlayers()) {
 			if (player != null) {
 				/*
 				 * Loop town/nation resident list

--- a/src/com/palmergames/bukkit/towny/permissions/GroupManagerSource.java
+++ b/src/com/palmergames/bukkit/towny/permissions/GroupManagerSource.java
@@ -6,6 +6,7 @@ import org.anjocaido.groupmanager.events.GMGroupEvent;
 import org.anjocaido.groupmanager.events.GMSystemEvent;
 import org.anjocaido.groupmanager.events.GMUserEvent;
 import org.anjocaido.groupmanager.permissions.AnjoPermissionsHandler;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -167,7 +168,7 @@ public class GroupManagerSource extends TownyPermissionSource {
 
 					Group group = event.getGroup();
 					// Update all players who are in this group.
-					for (Player toUpdate : BukkitTools.getOnlinePlayers()) {
+					for (Player toUpdate : Bukkit.getServer().getOnlinePlayers()) {
 						if (toUpdate != null) {
 							if (group.equals(getPlayerGroup(toUpdate))) {
 								//setup default modes
@@ -190,7 +191,7 @@ public class GroupManagerSource extends TownyPermissionSource {
 			try {
 				if (PermissionEventEnums.GMSystem_Action.valueOf(event.getAction().name()) != null) {
 					// Update all players.
-					for (Player toUpdate : BukkitTools.getOnlinePlayers()) {
+					for (Player toUpdate : Bukkit.getServer().getOnlinePlayers()) {
 						if (toUpdate != null) {
 							//setup default modes
 							String[] modes = getPlayerPermissionStringNode(toUpdate.getName(), PermissionNodes.TOWNY_DEFAULT_MODES.getNode()).split(",");

--- a/src/com/palmergames/bukkit/towny/permissions/PEXSource.java
+++ b/src/com/palmergames/bukkit/towny/permissions/PEXSource.java
@@ -2,6 +2,7 @@ package com.palmergames.bukkit.towny.permissions;
 
 import java.util.Arrays;
 
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -180,7 +181,7 @@ public class PEXSource extends TownyPermissionSource {
 						PermissionGroup group = (PermissionGroup) entity;
 
 						// Update all players who are in this group.
-						for (Player toUpdate : BukkitTools.getOnlinePlayers()) {
+						for (Player toUpdate : Bukkit.getServer().getOnlinePlayers()) {
 							if (toUpdate != null)
 								if (Arrays.asList(getPlayerGroups(toUpdate)).contains(group)) {
 									//setup default modes
@@ -216,7 +217,7 @@ public class PEXSource extends TownyPermissionSource {
 			try {
 				if (PermissionEventEnums.PEXSystem_Action.valueOf(event.getEventName()) != null) {
 					// Update all players.
-					for (Player toUpdate : BukkitTools.getOnlinePlayers()) {
+					for (Player toUpdate : Bukkit.getServer().getOnlinePlayers()) {
 						if (toUpdate != null) {
 							//setup default modes
 							String[] modes = getPlayerPermissionStringNode(toUpdate.getName(), PermissionNodes.TOWNY_DEFAULT_MODES.getNode()).split(",");

--- a/src/com/palmergames/bukkit/towny/permissions/TownyPerms.java
+++ b/src/com/palmergames/bukkit/towny/permissions/TownyPerms.java
@@ -16,6 +16,7 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
 
+import org.bukkit.Bukkit;
 import org.bukkit.configuration.MemorySection;
 import org.bukkit.entity.Player;
 import org.bukkit.permissions.Permission;
@@ -193,7 +194,7 @@ public class TownyPerms {
 	 */
 	public static void updateOnlinePerms() {
 		
-		for (Player player : BukkitTools.getOnlinePlayers()) {
+		for (Player player : Bukkit.getServer().getOnlinePlayers()) {
 			assignPermissions(null, player);
 		}
 		

--- a/src/com/palmergames/bukkit/towny/war/eventwar/War.java
+++ b/src/com/palmergames/bukkit/towny/war/eventwar/War.java
@@ -182,7 +182,7 @@ public class War {
 
 	public void end() {
 
-		for (Player player : BukkitTools.getOnlinePlayers())
+		for (Player player : Bukkit.getServer().getOnlinePlayers())
 			if (player != null)
 				sendStats(player);
 		plugin.getHUDManager().toggleAllWarHUD();

--- a/src/com/palmergames/bukkit/towny/war/eventwar/WarTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/war/eventwar/WarTimerTask.java
@@ -2,6 +2,7 @@ package com.palmergames.bukkit.towny.war.eventwar;
 
 import java.util.Hashtable;
 
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
 import com.palmergames.bukkit.towny.Towny;
@@ -15,7 +16,6 @@ import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.object.TownyUniverse;
 import com.palmergames.bukkit.towny.object.WorldCoord;
 import com.palmergames.bukkit.towny.tasks.TownyTimerTask;
-import com.palmergames.bukkit.util.BukkitTools;
 
 public class WarTimerTask extends TownyTimerTask {
 
@@ -41,7 +41,7 @@ public class WarTimerTask extends TownyTimerTask {
 
 		int numPlayers = 0;
 		Hashtable<TownBlock, WarZoneData> plotList = new Hashtable<TownBlock, WarZoneData>();
-		for (Player player : BukkitTools.getOnlinePlayers()) {
+		for (Player player : Bukkit.getServer().getOnlinePlayers()) {
 			if (player != null) {
 				numPlayers += 1;
 				TownyMessaging.sendDebugMsg("[War] " + player.getName() + ": ");

--- a/src/com/palmergames/bukkit/util/BukkitTools.java
+++ b/src/com/palmergames/bukkit/util/BukkitTools.java
@@ -47,8 +47,8 @@ public class BukkitTools {
 	 * Get an array of all online players
 	 * 
 	 * @return array of online players
+	 * @deprecated
 	 */
-	@SuppressWarnings("deprecation")
 	public static Collection<? extends Player> getOnlinePlayers() {
 		return getServer().getOnlinePlayers();
 	}


### PR DESCRIPTION
1. Deprecated the getOnlinePlayers() method in BukkitTools - the method getOnlinePlayers() in the Bukkit API has been changed to a collection and this is no longer necessary.
2. Reverted the deprecated BukkitTools.getOnlinePlayers() method to Bukkit.getServer().getOnlinePlayers()
3. Changed player.getItemInHand() to player.getInventory().getItemInMainHand()
