### PR TITLE
Fix for name changing with Vault economies that already support UUIDs

### DIFF
--- a/src/com/palmergames/bukkit/towny/TownyEconomyHandler.java
+++ b/src/com/palmergames/bukkit/towny/TownyEconomyHandler.java
@@ -161,6 +161,33 @@ public class TownyEconomyHandler {
 
 		return null;
 	}
+	
+	/**
+	 * Check if account exists
+	 * 
+	 * @param accountName
+	 * @return
+	 */
+	public static boolean hasEconomyAccount(String accountName) {
+
+		switch (Type) {
+
+		case ICO5:
+			return iConomy.hasAccount(accountName);
+
+		case REGISTER:
+			return Methods.getMethod().hasAccount(accountName);
+			
+		case VAULT:
+			return vaultEconomy.hasAccount(accountName);
+			
+		default:
+			break;
+
+		}
+
+		return false;
+	}
 
 	/**
 	 * Attempt to delete the economy account.

--- a/src/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
+++ b/src/com/palmergames/bukkit/towny/db/TownyDatabaseHandler.java
@@ -824,8 +824,10 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 			boolean isJailed = false;
 			int JailSpawn = 0;
 			
+			boolean transferBalance = !TownyEconomyHandler.hasEconomyAccount(filteredName);
+			
 			//get data needed for resident
-			if(TownySettings.isUsingEconomy()){
+			if(transferBalance && TownySettings.isUsingEconomy()){
 				try {
 					balance = resident.getHoldingBalance();
 					resident.removeAccount();
@@ -858,7 +860,7 @@ public abstract class TownyDatabaseHandler extends TownyDataSource {
 			universe.getResidentMap().put(filteredName.toLowerCase(), resident);
 			
 			//add everything back to the resident
-			if (TownySettings.isUsingEconomy()) {
+			if (transferBalance && TownySettings.isUsingEconomy()) {
 				//TODO
 				try {
 					resident.setBalance(balance, "Rename Player - Transfer to new account");


### PR DESCRIPTION
Checks the player's new name for an economy account. If found, the account isn't destroyed and recreated.


Vault has no function to remove accounts, so name changes cause Towny to create a second account with the same UUID. In CraftConomy, this throws a database exception, which is not caught by Towny and breaks name changes.