### PR TITLE
- /t spawn permission override

### DIFF
--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -1642,8 +1642,7 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 	public static void townSpawn(Player player, String[] split, Town town, String notAffordMSG, Boolean outpost) {
 
 		try {
-
-			boolean isTownyAdmin = TownyUniverse.getPermissionSource().isTownyAdmin(player);
+			boolean isTownyAdmin = TownyUniverse.getPermissionSource().has(player,PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_TOWN_SPAWN_OTHER.getNode());
 			Resident resident = TownyUniverse.getDataSource().getResident(player.getName());
 			Location spawnLoc;
 			TownSpawnLevel townSpawnPermission;

--- a/src/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
+++ b/src/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
@@ -182,6 +182,7 @@ public enum PermissionNodes {
 		TOWNY_COMMAND_TOWNYADMIN_TOWN_KICK("towny.command.townyadmin.town.kick"),
 		TOWNY_COMMAND_TOWNYADMIN_TOWN_DELETE("towny.command.townyadmin.town.delete"),
 		TOWNY_COMMAND_TOWNYADMIN_TOWN_RENAME("towny.command.townyadmin.town.rename"),
+		TOWNY_COMMAND_TOWNYADMIN_TOWN_SPAWN_OTHER("towny.command.townyadmin.town.spawn"),
 	
 	TOWNY_COMMAND_TOWNYADMIN_NATION("towny.command.townyadmin.nation.*"),
 		TOWNY_COMMAND_TOWNYADMIN_NATION_ADD("towny.command.townyadmin.nation.add"),

--- a/src/com/palmergames/bukkit/towny/permissions/TownyPermissionSource.java
+++ b/src/com/palmergames/bukkit/towny/permissions/TownyPermissionSource.java
@@ -314,7 +314,7 @@ public abstract class TownyPermissionSource {
 
 	public boolean isTownyAdmin(Player player) {
 
-		return ((player == null) || player.isOp()) || (plugin.isPermissions() && has(player, PermissionNodes.TOWNY_ADMIN.getNode()));
+		return ((player == null) || player.isOp()) || (plugin.isPermissions() && has(player, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_TOWN_SPAWN_OTHER.getNode()));
 
 	}
 

--- a/src/com/palmergames/bukkit/towny/permissions/TownyPermissionSource.java
+++ b/src/com/palmergames/bukkit/towny/permissions/TownyPermissionSource.java
@@ -314,7 +314,7 @@ public abstract class TownyPermissionSource {
 
 	public boolean isTownyAdmin(Player player) {
 
-		return ((player == null) || player.isOp()) || (plugin.isPermissions() && has(player, PermissionNodes.TOWNY_COMMAND_TOWNYADMIN_TOWN_SPAWN_OTHER.getNode()));
+		return ((player == null) || player.isOp()) || (plugin.isPermissions() && has(player, PermissionNodes.TOWNY_ADMIN.getNode()));
 
 	}
 

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -319,6 +319,7 @@ permissions:
             towny.command.townyadmin.purge: true
             owny.command.townyadmin.resident.delete: true
             towny.command.townyadmin.unclaim: true
+            towny.command.townyadmin.town.spawn: true
     
     towny.command.townyadmin.set.*:
         description: User can access the admin set commands.


### PR DESCRIPTION
Added permission: towny.command.townyadmin.town.spawn in plugin.yml it is added to townyadmin.*
And added to the PermissionNodes.java its checked for in the command instead of the townyadmin perm