### PR TITLE
Quick fix for the NPE caused by Nations loading

### DIFF
--- a/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -913,6 +913,8 @@ public class TownySQLSource extends TownyFlatFileSource {
                     town.setUuid(UUID.fromString(rs.getString("uuid")));
                 } catch (IllegalArgumentException ee) {
                     town.setUuid(UUID.randomUUID());
+                }  catch (NullPointerException ee) {
+                    town.setUuid(UUID.randomUUID());
                 }
 
 
@@ -1013,6 +1015,8 @@ public class TownySQLSource extends TownyFlatFileSource {
                 try {
                     nation.setUuid(UUID.fromString(rs.getString("uuid")));
                 } catch (IllegalArgumentException ee) {
+                    nation.setUuid(UUID.randomUUID());
+                } catch (NullPointerException ee){
                     nation.setUuid(UUID.randomUUID());
                 }
             }


### PR DESCRIPTION
Yeah Quickfix, literally all we needed was 1 catch clause,
This gave me the oppertunity to check if the SQL_SCHEMA i did actually does work between multiple (not only 2) versions, which it does thankfully