### PR TITLE
Added /t unclaim outpost command

### DIFF
--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -3,7 +3,6 @@ package com.palmergames.bukkit.towny.command;
 import ca.xshade.bukkit.questioner.Questioner;
 import ca.xshade.questionmanager.Option;
 import ca.xshade.questionmanager.Question;
-
 import com.earth2me.essentials.Teleport;
 import com.earth2me.essentials.User;
 import com.palmergames.bukkit.towny.Towny;
@@ -46,8 +45,6 @@ import com.palmergames.bukkit.util.ChatTools;
 import com.palmergames.bukkit.util.Colors;
 import com.palmergames.bukkit.util.NameValidation;
 import com.palmergames.util.StringMgmt;
-import com.palmergames.util.TimeTools;
-
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
@@ -61,7 +58,6 @@ import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.plugin.Plugin;
 
 import javax.naming.InvalidNameException;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -2555,6 +2551,9 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 			player.sendMessage(ChatTools.formatCommand(TownySettings.getLangString("mayor_sing"), "/town unclaim", "", TownySettings.getLangString("mayor_help_6")));
 			player.sendMessage(ChatTools.formatCommand(TownySettings.getLangString("mayor_sing"), "/town unclaim", "[circle/rect] [radius]", TownySettings.getLangString("mayor_help_7")));
 			player.sendMessage(ChatTools.formatCommand(TownySettings.getLangString("mayor_sing"), "/town unclaim", "all", TownySettings.getLangString("mayor_help_8")));
+			player.sendMessage(ChatTools.formatCommand(TownySettings.getLangString("mayor_sing"), "/town unclaim", "outpost", TownySettings.getLangString("mayor_help_9")));
+			// THIS IS HIGHLY IMPORTANT ( LANG STRING: " MAYOR HELP 9 " ) DOES NOT EXIST! THIS SHOULD BE ADDED, YET I HAVE NO IDEA HOW TO ADD LANG STRINGS xD PLEASE REMOVE THIS COMMENT AFTERWARDS.
+			// Lang String required
 		} else {
 			Resident resident;
 			Town town;
@@ -2571,6 +2570,8 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 				if (split.length == 1 && split[0].equalsIgnoreCase("all")) {
 					new TownClaim(plugin, player, town, null, false, false, false).start();
 					// townUnclaimAll(town);
+					// If the unclaim code knows its an outpost or not, doesnt matter its only used once the world deletes the townblock, where it takes the value from the townblock.
+					// Which is why in AreaSelectionUtil, since outpost is not parsed in the main claiming of a section, it is parsed in the unclaiming with the circle, rect & all options.
 				} else {
 					selection = AreaSelectionUtil.selectWorldCoordArea(town, new WorldCoord(world.getName(), Coord.parseCoord(plugin.getCache(player).getLastLocation())), split);
 					selection = AreaSelectionUtil.filterOwnedBlocks(town, selection);

--- a/src/com/palmergames/bukkit/towny/db/FlatFile_Task.java
+++ b/src/com/palmergames/bukkit/towny/db/FlatFile_Task.java
@@ -9,8 +9,6 @@ public class FlatFile_Task {
 	
 	/**
 	 * Constructor to save a list
-	 * 
-	 * @param type
 	 * @param list
 	 * @param path
 	 */

--- a/src/com/palmergames/bukkit/towny/object/TownyUniverse.java
+++ b/src/com/palmergames/bukkit/towny/object/TownyUniverse.java
@@ -1223,4 +1223,21 @@ public class TownyUniverse extends TownyObject {
 		return NameValidation.checkAndFilterArray(arr);
 	}
 
+	/**
+	 * @author - Articdive
+	 * @param minecraftcoordinates - List of minecraft coordinates you should probably parse town.getAllOutpostSpawns()
+	 * @param tb - TownBlock to check if its contained..
+	 * @note - Pretty much this method checks if a townblock is contained within a list of locations.
+	 */
+	public static boolean isTownBlockLocContainedInTownOutposts(List<Location> minecraftcoordinates, TownBlock tb) {
+		if (minecraftcoordinates != null && tb != null) {
+			for (Location minecraftcoordinate : minecraftcoordinates) {
+				if (Coord.parseCoord(minecraftcoordinate).equals(tb.getCoord())) {
+					return true; // Yes the TownBlock is considered an outpost by the Town
+				}
+			}
+		}
+		return false;
+	}
+
 }

--- a/src/com/palmergames/bukkit/towny/tasks/ProtectionRegenTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/ProtectionRegenTask.java
@@ -1,8 +1,9 @@
 package com.palmergames.bukkit.towny.tasks;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import com.palmergames.bukkit.towny.Towny;
+import com.palmergames.bukkit.towny.regen.NeedsPlaceholder;
+import com.palmergames.bukkit.towny.regen.TownyRegenAPI;
+import com.palmergames.bukkit.towny.regen.block.BlockLocation;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
@@ -16,10 +17,8 @@ import org.bukkit.material.Attachable;
 import org.bukkit.material.Door;
 import org.bukkit.material.PistonExtensionMaterial;
 
-import com.palmergames.bukkit.towny.Towny;
-import com.palmergames.bukkit.towny.regen.NeedsPlaceholder;
-import com.palmergames.bukkit.towny.regen.TownyRegenAPI;
-import com.palmergames.bukkit.towny.regen.block.BlockLocation;
+import java.util.ArrayList;
+import java.util.List;
 
 @SuppressWarnings("deprecation")
 public class ProtectionRegenTask extends TownyTimerTask {

--- a/src/com/palmergames/bukkit/towny/tasks/TownClaim.java
+++ b/src/com/palmergames/bukkit/towny/tasks/TownClaim.java
@@ -193,8 +193,14 @@ public class TownClaim extends Thread {
 
 		try {
 			final TownBlock townBlock = worldCoord.getTownBlock();
-			if (town != townBlock.getTown() && !force)
+			if (town != townBlock.getTown() && !force) {
 				throw new TownyException(TownySettings.getLangString("msg_area_not_own"));
+			}
+			if (!townBlock.isOutpost() && townBlock.hasTown()) {
+				if (TownyUniverse.isTownBlockLocContainedInTownOutposts(townBlock.getTown().getAllOutpostSpawns(), townBlock)) {
+					townBlock.setOutpost(true);
+				}
+			}
 
 			Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, new Runnable() {
 

--- a/src/com/palmergames/bukkit/towny/utils/AreaSelectionUtil.java
+++ b/src/com/palmergames/bukkit/towny/utils/AreaSelectionUtil.java
@@ -1,9 +1,5 @@
 package com.palmergames.bukkit.towny.utils;
 
-import java.text.Format;
-import java.util.ArrayList;
-import java.util.List;
-
 import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
@@ -12,8 +8,12 @@ import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.object.TownBlockOwner;
+import com.palmergames.bukkit.towny.object.TownyUniverse;
 import com.palmergames.bukkit.towny.object.WorldCoord;
 import com.palmergames.util.StringMgmt;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class AreaSelectionUtil {
 
@@ -38,6 +38,21 @@ public class AreaSelectionUtil {
 				}
 			} else if (args[0].equalsIgnoreCase("auto")) {
 				out = selectWorldCoordAreaRect(owner, pos, args);
+			} else if (args[0].equalsIgnoreCase("outpost")) {
+				TownBlock tb = pos.getTownBlock();
+				if (!tb.isOutpost() && tb.hasTown()) { // isOutpost(), only for mysql however, if we include this we can skip the outposts on flatfile so less laggy!
+					Town town = tb.getTown();
+					if (TownyUniverse.isTownBlockLocContainedInTownOutposts(town.getAllOutpostSpawns(), tb)) {
+						tb.setOutpost(true);
+						out.add(pos);
+					} else {
+						throw new TownyException("You are not unclaiming an outpost, please use /t unclaim");
+						// Lang String required.
+					}
+				}
+				if (tb.isOutpost()) { // flatfile skipper
+					out.add(pos);
+				}
 			} else {
 				try {
 					Integer.parseInt(args[0]);


### PR DESCRIPTION
- The /t unclaim outpost command does following:
It checks the arguments when in the AreaSelectionUtil.
If the value is outpost in the arguments it checks against the town
if the townblock really is an outpost.
If it is, it sets the outpost value to true and returns the townblock the
player is on (standard behavior for unclaiming a townblock)
since the code for deleting a townblock does remove the outpost itself from
the town.