### PR TITLE
Convert Readme to Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-Towny Advanced is developed by LlmDl.
+<p align="center">
+<img src="http://towny.palmergames.com/wp-content/uploads/2013/01/townylogo.png" height="155" width="153">
+</p>
+
+# Towny Advanced
+### Developed by [LlmDl](https://github.com/LlmDl)
+
 
 I took over from ElgarL after MC 1.8 was released. Past developers have included: Shadeness, FuzzieWuzzie, ElgarL. 
 With help coming from other developers from time to time including dumptruckman, ole8pie, SwearWord, gravypod, andrewyunt and more.
@@ -10,14 +16,15 @@ Releases, Dev builds and all other plugins I maintain/dev are available from...
 
 * http://palmergames.com/towny
 
-If you need help, join us in our IRC channel #towny on the Esper.net network: ( http://webchat.esper.net/?channels=towny )
+#### Connect
+If you need help, join us in our [IRC channel #towny](http://webchat.esper.net/?channels=towny) on the Esper.net network.
 If you are a server admin that wants to get cutting edge updates on the development of the plugin and want to help test things before they become public,
-join us in our Discord server ( https://discord.gg/gnpVs5m ) 
+join us in our [Discord server]( https://discord.gg/gnpVs5m )
 
 
-Licensing:
+#### Licensing
 
-http://creativecommons.org/licenses/by-nc-nd/3.0/
+Towny is licensed under the [Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported (CC BY-NC-ND 3.0) License ](http://creativecommons.org/licenses/by-nc-nd/3.0/)
 
 We don't object to you making your own forks and builds but we do object to people being selfish, which is why we specify No Derivative Works.
 If you want to modify the code to add some nice feature the least you can do is ask and submit a pull request to allow everyone to benefit from it.


### PR DESCRIPTION
Converts the Readme from a Text file to Markdown. This allows for a slightly cleaner feel than a raw text file when viewing from GitHub (subjective), and adds the ability to use HTML tags for various elements if desired. (Such as the Towny logo)

Just thought I'd give back to the project a bit. ¯\\\_(ツ)_/¯